### PR TITLE
Removed fixed version of django-model-utils and set to >=4.2.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [2.0.5]
+
+### Fixed
+* django-model-utils changed from ==4.2.0 to >=4.2.0
+
 
 ## [2.0.4]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.4
+current_version = 2.0.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url='https://github.com/txerpa/dj-tximmutability',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=["Django>=2.2,<3.3", "django-model-utils==4.2.0"],
+    install_requires=["Django>=2.2,<4", "django-model-utils>=4.2.0"],
     python_requires=">=3.8",
     license='MIT License',
     zip_safe=False,

--- a/tximmutability/__init__.py
+++ b/tximmutability/__init__.py
@@ -1,4 +1,4 @@
 """Django Txerpa Immutability"""
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 __author__ = "Marija Milicevic"
 __email__ = "marija.milicevic@txerpa.com"


### PR DESCRIPTION
Removed fixed version of django-model-utils and set to >=4.2.0
Bump version: 2.0.4 → 2.0.5